### PR TITLE
Sync to current blockheight

### DIFF
--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -17,6 +17,7 @@ type Config struct {
 	TendermintApi       string `mapstructure:"TENDERMINT_API"`
 	TendermintWs        string `mapstructure:"TENDERMINT_WS"`
 	ChainID             string `mapstructure:"CHAIN_ID"`
+	IndexerID           int64  `mapstructure:"INDEXER_ID"`
 	Bech32PrefixAccAddr string `mapstructure:"BECH32_PREF_ACC_ADDR"`
 	Bech32PrefixAccPub  string `mapstructure:"BECH32_PREF_ACC_PUB"`
 	DBHost              string `mapstructure:"DB_HOST"`
@@ -37,6 +38,7 @@ var (
 		"TENDERMINT_API",
 		"TENDERMINT_WS",
 		"CHAIN_ID",
+		"INDEXER_ID",
 		"BECH32_PREF_ACC_ADDR",
 		"BECH32_PREF_ACC_PUB",
 		"DB_HOST",
@@ -70,6 +72,7 @@ func main() {
 
 	app := indexer.NewIndexer(indexer.IndexerAppParams{
 		ChainID:             c.ChainID,
+		IndexerID:           c.IndexerID,
 		Bech32PrefixAccAddr: c.Bech32PrefixAccAddr,
 		Bech32PrefixAccPub:  c.Bech32PrefixAccPub,
 		ArkeoApi:            c.ArkeoApi,

--- a/db/ddl/create_indexer_status.sql
+++ b/db/ddl/create_indexer_status.sql
@@ -2,7 +2,7 @@ drop table if exists indexer_status;
 
 create table indexer_status
 (
-    id          serial not null
+    id          numeric not null
         constraint indexer_status_pk
             primary key,
     created     timestamptz default now() not null,

--- a/db/ddl/create_indexer_status.sql
+++ b/db/ddl/create_indexer_status.sql
@@ -1,0 +1,11 @@
+drop table if exists indexer_status;
+
+create table indexer_status
+(
+    id          serial not null
+        constraint indexer_status_pk
+            primary key,
+    created     timestamptz default now() not null,
+    updated     timestamptz default now() not null,
+    height      numeric not null check ( height >= 0 )
+);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
 
   arkeo-protocol:
     container_name: arkeo-protocol
-    image: arkeo-protocol:latest
+    image: ghcr.io/arkeonetwork/arkeo:latest
     environment:
       - ARKEOD_RPC_LADDR=tcp://0.0.0.0:26657
     networks:
@@ -38,7 +38,6 @@ services:
       - docker/dev/docker.env
     depends_on:
       - postgres
-      - arkeo-protocol
     networks:
       - arkeo
 

--- a/docker/dev/docker.env
+++ b/docker/dev/docker.env
@@ -2,6 +2,7 @@
 API_LISTEN="0.0.0.0:7777"
 
 # indexer
+INDEXER_ID="0"
 CHAIN_ID="arkeo"
 BECH32_PREF_ACC_ADDR="arkeo"
 BECH32_PREF_ACC_PUB="arkeopub"

--- a/docker/dev/local.env
+++ b/docker/dev/local.env
@@ -2,6 +2,7 @@
 API_LISTEN="localhost:7777"
 
 # indexer
+INDEXER_ID="0"
 CHAIN_ID="arkeo"
 BECH32_PREF_ACC_ADDR="arkeo"
 BECH32_PREF_ACC_PUB="arkeopub"

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -82,7 +82,8 @@ func (a *IndexerApp) start() {
 	}
 	log.Infof("Starting historical syncing from block height: %d", a.Height)
 	// unsure how to deal with syncronization here. Ideally we kick off new thread to background historical sync
-	// while we keep consuming events that are coming in real time.
+	// while we keep consuming events that are coming in real time. Currently we run the risk of missing
+	// some events in the transition from historical to real time.
 	a.consumeHistoricalEvents(client)
 	a.IsSynced = true
 	a.consumeEvents(client)

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -112,7 +112,7 @@ func (a *IndexerApp) handleBlockEvent(height int64) error {
 		ID:     a.params.IndexerID,
 		Height: uint64(height),
 	}
-	_, err := a.db.UpdateIndexerStatus(&indexerStatus)
+	_, err := a.db.InsertIndexerStatus(&indexerStatus)
 	if err != nil {
 		return errors.Wrapf(err, "error updating indexer status for %d height %d", indexerStatus.ID, indexerStatus.Height)
 	}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -19,13 +19,16 @@ type IndexerAppParams struct {
 	ChainID             string
 	Bech32PrefixAccAddr string
 	Bech32PrefixAccPub  string
+	IndexerID           int64
 	db.DBConfig
 }
 
 type IndexerApp struct {
-	params IndexerAppParams
-	db     *db.DirectoryDB
-	done   chan struct{}
+	Height   uint64
+	IsSynced bool
+	params   IndexerAppParams
+	db       *db.DirectoryDB
+	done     chan struct{}
 }
 
 func NewIndexer(params IndexerAppParams) *IndexerApp {
@@ -57,6 +60,22 @@ func (a *IndexerApp) start() {
 		panic(fmt.Sprintf("error starting client: %+v", err))
 	}
 	defer client.Stop()
+
+	// determine last seen block from db
+
+	indexerStatus, err := a.db.FindIndexerStatus(a.params.IndexerID)
+	if err != nil {
+		panic(fmt.Sprintf("error getting indexer state from db: %+v", err))
+	}
+
+	a.IsSynced = false
+	if indexerStatus == nil {
+		// this is the first time we have started the indexer wit this db, sync from heigh of 0
+		a.Height = 0
+	} else {
+		a.Height = indexerStatus.Height
+	}
+
 	a.consumeEvents(client)
 	a.done <- struct{}{}
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -91,8 +91,7 @@ func (a *IndexerApp) start() {
 		if err != nil {
 			log.Infof("Historical syncing failed")
 			complete <- false
-			// should we PANIC here?
-			return
+			panic(fmt.Sprintf("Historical syncing failed: %+v", err))
 		}
 		log.Infof("Historical syncing completed")
 		a.IsSynced.Store(true)

--- a/pkg/db/indexer.go
+++ b/pkg/db/indexer.go
@@ -2,12 +2,13 @@ package db
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/pkg/errors"
 )
 
 type IndexerStatus struct {
-	ID     string `db:"id"`
+	ID     int64  `db:"id"`
 	Height uint64 `db:"height"`
 }
 
@@ -41,18 +42,18 @@ func (d *DirectoryDB) UpdateIndexerStatus(indexerStatus *IndexerStatus) (*Entity
 	)
 }
 
-func (d *DirectoryDB) FindIndexerStatus(id string) (*IndexerStatus, error) {
+func (d *DirectoryDB) FindIndexerStatus(id int64) (*IndexerStatus, error) {
 	conn, err := d.getConnection()
 	defer conn.Release()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error obtaining db connection")
 	}
-	indexerStatus := IndexerStatus{}
+	indexerStatus := IndexerStatus{Height: math.MaxUint64} // used to designate not found... need a better way!
 	if err = selectOne(conn, sqlFindIndexerStatus, &indexerStatus, id); err != nil {
 		return nil, errors.Wrapf(err, "error selecting")
 	}
 	// not found
-	if indexerStatus.ID == "" {
+	if indexerStatus.Height == math.MaxUint64 {
 		return nil, nil
 	}
 	return &indexerStatus, nil

--- a/pkg/db/indexer.go
+++ b/pkg/db/indexer.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+type IndexerStatus struct {
+	ID     string `db:"id"`
+	Height uint64 `db:"height"`
+}
+
+func (d *DirectoryDB) InsertIndexerStatus(indexerStatus *IndexerStatus) (*Entity, error) {
+	if indexerStatus == nil {
+		return nil, fmt.Errorf("nil IndexerStatus")
+	}
+	conn, err := d.getConnection()
+	defer conn.Release()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error obtaining db connection")
+	}
+
+	return insert(conn, sqlInsertIndexerStatus, indexerStatus.ID, indexerStatus.Height)
+}
+
+func (d *DirectoryDB) UpdateIndexerStatus(indexerStatus *IndexerStatus) (*Entity, error) {
+	if indexerStatus == nil {
+		return nil, fmt.Errorf("nil IndexerStatus")
+	}
+	conn, err := d.getConnection()
+	defer conn.Release()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error obtaining db connection")
+	}
+
+	return update(conn,
+		sqlUpdateIndexerStatus,
+		indexerStatus.ID,
+		indexerStatus.Height,
+	)
+}
+
+func (d *DirectoryDB) FindIndexerStatus(id string) (*IndexerStatus, error) {
+	conn, err := d.getConnection()
+	defer conn.Release()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error obtaining db connection")
+	}
+	indexerStatus := IndexerStatus{}
+	if err = selectOne(conn, sqlFindIndexerStatus, &indexerStatus, id); err != nil {
+		return nil, errors.Wrapf(err, "error selecting")
+	}
+	// not found
+	if indexerStatus.ID == "" {
+		return nil, nil
+	}
+	return &indexerStatus, nil
+}

--- a/pkg/db/indexer.go
+++ b/pkg/db/indexer.go
@@ -22,7 +22,7 @@ func (d *DirectoryDB) InsertIndexerStatus(indexerStatus *IndexerStatus) (*Entity
 		return nil, errors.Wrapf(err, "error obtaining db connection")
 	}
 
-	return insert(conn, sqlInsertIndexerStatus, indexerStatus.ID, indexerStatus.Height)
+	return insert(conn, sqlUpsertIndexerStatus, indexerStatus.ID, indexerStatus.Height)
 }
 
 func (d *DirectoryDB) UpdateIndexerStatus(indexerStatus *IndexerStatus) (*Entity, error) {

--- a/pkg/db/indexer_sql.go
+++ b/pkg/db/indexer_sql.go
@@ -1,0 +1,7 @@
+package db
+
+var (
+	sqlInsertIndexerStatus = `insert into indexer_status(id,height) values ($1,$2) returning id, created, updated`
+	sqlUpdateIndexerStatus = `update indexer_status set height = $2, updated = now() where id = $1 returning id, created, updated`
+	sqlFindIndexerStatus   = `select id,height from indexer_status where id = $1`
+)

--- a/pkg/db/indexer_sql.go
+++ b/pkg/db/indexer_sql.go
@@ -1,7 +1,11 @@
 package db
 
 var (
-	sqlInsertIndexerStatus = `insert into indexer_status(id,height) values ($1,$2) returning id, created, updated`
+	sqlUpsertIndexerStatus = `
+		insert into indexer_status(id,height) values ($1,$2)
+		on conflict on constraint indexer_status_pk do update 
+		set height = $2, updated = now() returning id, created, updated
+	`
 	sqlUpdateIndexerStatus = `update indexer_status set height = $2, updated = now() where id = $1 returning id, created, updated`
 	sqlFindIndexerStatus   = `select id,height from indexer_status where id = $1`
 )

--- a/pkg/db/indexer_test.go
+++ b/pkg/db/indexer_test.go
@@ -11,7 +11,7 @@ func TestInsertIndexerStatus(t *testing.T) {
 	}
 
 	entity, err := db.InsertIndexerStatus(&IndexerStatus{
-		ID:     "0",
+		ID:     0,
 		Height: 55,
 	})
 
@@ -29,7 +29,7 @@ func TestUpdateIndexerStatus(t *testing.T) {
 	}
 
 	entity, err := db.UpdateIndexerStatus(&IndexerStatus{
-		ID:     "0",
+		ID:     0,
 		Height: 65,
 	})
 
@@ -46,7 +46,8 @@ func TestFindIndexerStatus(t *testing.T) {
 		t.Errorf("error getting db: %+v", err)
 	}
 
-	id := "0"
+	var id int64
+	id = 0
 	indexerStatus, err := db.FindIndexerStatus(id)
 	if err != nil {
 		t.Errorf("error finding indexer status: %+v", err)
@@ -54,7 +55,7 @@ func TestFindIndexerStatus(t *testing.T) {
 	}
 	log.Infof("found indexer status %d", indexerStatus.ID)
 
-	id = "nosuchthing"
+	id = 555556
 	indexerStatus, err = db.FindIndexerStatus(id)
 	if err != nil {
 		t.Errorf("error finding provider: %+v", err)

--- a/pkg/db/indexer_test.go
+++ b/pkg/db/indexer_test.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestInsertIndexerStatus(t *testing.T) {
+	db, err := New(config)
+	if err != nil {
+		t.Errorf("error getting db: %+v", err)
+	}
+
+	entity, err := db.InsertIndexerStatus(&IndexerStatus{
+		ID:     "0",
+		Height: 55,
+	})
+
+	if err != nil {
+		t.Errorf("error inserting indexer: %+v", err)
+		t.FailNow()
+	}
+	log.Infof("inserted indexer %d", entity.ID)
+}
+
+func TestUpdateIndexerStatus(t *testing.T) {
+	db, err := New(config)
+	if err != nil {
+		t.Errorf("error getting db: %+v", err)
+	}
+
+	entity, err := db.UpdateIndexerStatus(&IndexerStatus{
+		ID:     "0",
+		Height: 65,
+	})
+
+	if err != nil {
+		t.Errorf("error updated indexer: %+v", err)
+		t.FailNow()
+	}
+	log.Infof("updated indexer %d", entity.ID)
+}
+
+func TestFindIndexerStatus(t *testing.T) {
+	db, err := New(config)
+	if err != nil {
+		t.Errorf("error getting db: %+v", err)
+	}
+
+	id := "0"
+	indexerStatus, err := db.FindIndexerStatus(id)
+	if err != nil {
+		t.Errorf("error finding indexer status: %+v", err)
+		t.FailNow()
+	}
+	log.Infof("found indexer status %d", indexerStatus.ID)
+
+	id = "nosuchthing"
+	indexerStatus, err = db.FindIndexerStatus(id)
+	if err != nil {
+		t.Errorf("error finding provider: %+v", err)
+		t.FailNow()
+	}
+	if indexerStatus != nil {
+		t.Errorf("expected nil but got %v", indexerStatus)
+	}
+}

--- a/pkg/db/utils.go
+++ b/pkg/db/utils.go
@@ -45,7 +45,7 @@ func update(conn *pgxpool.Conn, sql string, params ...interface{}) (*Entity, err
 
 // if the query returns no rows, the passed target remains unchanged. target must be a pointer
 func selectOne(conn *pgxpool.Conn, sql string, target interface{}, params ...interface{}) error {
-	if err := pgxscan.Get(context.Background(), conn, target, sqlFindProvider, params...); err != nil {
+	if err := pgxscan.Get(context.Background(), conn, target, sql, params...); err != nil {
 		unwrapped := errors.Unwrap(err)
 		if unwrapped != nil && unwrapped.Error() == "no rows in result set" {
 			return nil


### PR DESCRIPTION
adds functionality on startup to sync past events up to current block height.

Questions for @asamere 

1. Adding ability to interrupt thread for historic sync ?
2. Failure mode for historical sync
3. Go file formatting 
4. should we get rid of the indexer ID?  Theoretically in the future we could have multiple indexers, but don't really see the use case at the moment.
5. a.Height is "lazy" synched, but maybe we should make it atomic as well. 